### PR TITLE
bug: Fix no filter options

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,6 +34,15 @@ gulp.task('images', () => {
     .pipe(gulp.dest('./dist/img'));
 });
 
+// Generate webp images for source folder
+gulp.task('src-images', () => {
+  return gulp.src(['./src/img/*_300w.jpg', './src/img/diet.svg'])
+    .pipe(size({showFiles: true}))
+    .pipe(webp())
+    .pipe(size({showFiles: true}))
+    .pipe(gulp.dest('./src/img'));
+});
+
 // Process main.js by concat activate.js then minify
 gulp.task('main.js', () => {
   return gulp.src(['./src/js/activate-sw.js', './src/js/main.js'])

--- a/src/index.html
+++ b/src/index.html
@@ -37,8 +37,8 @@
     </section>
   </main>
 
-  <script async defer type="application/javascript" charset="utf-8" src="./js/helper.js"></script>
-  <script async defer type="application/javascript" charset="utf-8" src="./js/main.js"></script>
+  <script defer type="application/javascript" charset="utf-8" src="./js/helper.js"></script>
+  <script defer type="application/javascript" charset="utf-8" src="./js/main.js"></script>
   <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB5_piZRacxa_t9dIC9G5hDBtKwh08Er3Q&libraries=places&callback=initMap"></script>
 
   <footer id="footer">

--- a/src/restaurant.html
+++ b/src/restaurant.html
@@ -114,9 +114,9 @@
 
   <!-- Beginning scripts -->
   <!-- Database helpers -->
-  <script async defer type="application/javascript" charset="utf-8" src="./js/helper.js"></script>
+  <script defer type="application/javascript" charset="utf-8" src="./js/helper.js"></script>
   <!-- Main javascript file -->
-  <script async defer type="application/javascript" src="./js/restaurant_info.js"></script>
+  <script defer type="application/javascript" src="./js/restaurant_info.js"></script>
   <!-- Google Maps -->
   <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB5_piZRacxa_t9dIC9G5hDBtKwh08Er3Q&libraries=places&callback=initMap"></script>
   <!-- End scripts -->


### PR DESCRIPTION
Use defer only for local js script in index.html and restaurant.html
instead of async. Async will cause files to be loaded after
'DOMContentOnLoad' event is fired which is required to populate filter
options.

Verified that update doesn't drop performance rating below 90.